### PR TITLE
ci: skip Claude code review for bot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Skip bot-authored PRs (dependabot, etc.) — they don't need AI code review
+    # and the action will fail with "non-human actor" if they trigger it.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
+
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Adds `if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'` guard to the `claude-review` job.

## Problem

dependabot PRs trigger the `claude-code-review` workflow, but the Anthropic action rejects non-human actors. This causes all dependabot PRs to show a failing CI check.

## Fix

Explicit skip for bot actors. Bot dep-bump PRs don't need AI code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)