### PR TITLE
fix(lockfile): sync jiti to 2.6.1 to match package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@typescript-eslint/parser": "^8.17.0",
         "@vitest/coverage-v8": "^2.1.9",
         "eslint": "^9.17.0",
+        "jiti": "^2.6.1",
         "prettier": "^3.4.2",
         "tsx": "^4.20.5",
         "typescript": "^5.9.3",
@@ -3386,13 +3387,11 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
-      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }


### PR DESCRIPTION
## Problem

Master has a \`package.json\` / \`package-lock.json\` mismatch on jiti: package.json declares \`^2.6.1\` but the lockfile has \`2.5.1\`. This breaks \`npm ci\` with:

\`\`\`
Invalid: lock file's jiti@2.5.1 does not satisfy jiti@2.6.1
\`\`\`

Introduced in df5a6da (part of #18), which added jiti to devDependencies without regenerating the lockfile.

## Fix

Regenerated via \`npm install --package-lock-only\`. Minimal diff: only the jiti lockfile entry changes (2.5.1 → 2.6.1), plus removal of the stale \`optional\` / \`peer\` flags from when it was transitive-only.

\`npm ci\` now exits 0 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)