### PR TITLE
fix(lint): use optional chain in alerting.ts

### DIFF
--- a/src/services/alerting.ts
+++ b/src/services/alerting.ts
@@ -230,7 +230,7 @@ export class AlertingService {
     const instances = await this.listAlertInstances();
     return instances.filter(
       (instance) =>
-        instance.labels && instance.labels.__alert_rule_uid__ === ruleUid,
+        instance.labels?.__alert_rule_uid__ === ruleUid,
     );
   }
 


### PR DESCRIPTION
## Summary

#21 (vitest 4.x bump) pulled in a newer \`@typescript-eslint\` that upgrades \`prefer-optional-chain\` from warning to error. One hit in \`src/services/alerting.ts\`:

\`\`\`diff
- instance.labels && instance.labels.__alert_rule_uid__ === ruleUid
+ instance.labels?.__alert_rule_uid__ === ruleUid
\`\`\`

Applied via \`eslint --fix\`. After this, \`npm run lint\` reports 0 errors on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)